### PR TITLE
Update environment variable descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ Copy `.env.example` → `.env` and set values:
 | Name | Description |
 |------|-------------|
 | `DATABASE_URL` | Prisma/Postgres connection string |
-| `AUTH_SECRET`, `AUTH_URL` | Required for Auth.js (NextAuth v5) |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT` | Local Postgres container configuration (used in Docker + DATABASE_URL) |
+| `AUTH_SECRET` | Required for Auth.js (NextAuth v5) |
+| `AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET` | GitHub OAuth credentials for Auth.js |
+| `AUTH_TRUST_HOST` | Set `true` for local/dev environments |
 | `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET` | Cloudinary credentials for file uploads |
+| `CLOUDINARY_UPLOAD_FOLDER` | Default Cloudinary folder for uploads |
 | `PREVIEW_SECRET` | Secret token for Draft Preview mode |
 
 ---


### PR DESCRIPTION
This pull request updates the environment variable documentation in `README.md` to provide clearer guidance on required variables for local development and authentication. Several new variables have been added, and existing descriptions have been clarified to help developers configure their environment more easily.

**Environment variable documentation improvements:**

* Added documentation for local Postgres container variables: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, and `POSTGRES_PORT`, clarifying their use with Docker and `DATABASE_URL`.
* Split out and clarified authentication variables: `AUTH_SECRET` is now listed separately, and new entries for `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` (GitHub OAuth credentials for Auth.js) have been added.
* Added `AUTH_TRUST_HOST` variable to indicate when to set it for local/dev environments.
* Added `CLOUDINARY_UPLOAD_FOLDER` to specify the default Cloudinary folder for uploads.